### PR TITLE
Grohe have changed there endpoint

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -22,7 +22,7 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-BASE_URL = 'https://idp-apigw.cloud.grohe.com/v3/iot/'
+BASE_URL = 'https://idp2-apigw.cloud.grohe.com/v3/iot/'
 
 GROHE_SENSE_TYPE = 101 # Type identifier for the battery powered water detector
 GROHE_SENSE_GUARD_TYPE = 103 # Type identifier for sense guard, the water guard installed on your water pipe


### PR DESCRIPTION
Old endpoint is using a revoked certificate:
https://idp-apigw.cloud.grohe.com/v3/iot/

New endpoint seems to be:
https://idp2-apigw.cloud.grohe.com/v3/iot/

Judging from info in: https://github.com/FlorianSW/grohe-ondus-api-java/blob/master/src/main/java/org/grohe/ondus/api/OndusService.java