### PR TITLE
Get refresh_token automatically based on the username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,12 @@ Graphing water consumption is also nice. Note that the data returned by Grohe's 
 ## Installation
 - Ensure everything is set up and working in Grohe's Ondus app
 - Copy this folder to `<config_dir>/custom_components/grohe_sense/`
-- Go to https://idp2-apigw.cloud.grohe.com/v3/iot/oidc/login
-- Bring up developer tools
-- Log in, that'll try redirecting your browser with a 302 to an url starting with `ondus://idp2-apigw.cloud.grohe.com/v3/iot/oidc/token`, which an off-the-shelf Chrome will ignore
-- You should see this failed redirect in your developer tools. Copy out the full URL and replace `ondus` with `https` and visit that URL (will likely only work once, and will expire, so don't be too slow).
-- This gives you a json response. Save it and extract refresh_token from it (manually, or `jq .refresh_token < file.json`)
 
 Put the following in your home assistant config (N.B., format has changed, this component is no longer configured as a sensor platform)
 ```
 grohe_sense:
-  refresh_token: "YOUR_VERY_VERY_LONG_REFRESH_TOKEN"
+  username: "YOUR_GROHE_EMAIL"
+  password: "YOUR_GROHE_PASSWORD"
 ```
 
 ## Remarks on the "API"

--- a/__init__.py
+++ b/__init__.py
@@ -60,7 +60,7 @@ async def get_token(hass, username, password):
         except Exception as e:
             _LOGGER.error('Get Refresh Token Action Exception %s', str(e))
         else:
-            ondus_url = response.headers['Location'].url.replace('ondus', 'https')
+            ondus_url = response.headers['Location'].replace('ondus', 'https')
             try:
                 response = await session.get(url = ondus_url, cookies = cookie)
             except Exception as e:

--- a/__init__.py
+++ b/__init__.py
@@ -34,7 +34,7 @@ GROHE_SENSE_GUARD_TYPE = 103 # Type identifier for sense guard, the water guard 
 
 GroheDevice = collections.namedtuple('GroheDevice', ['locationId', 'roomId', 'applianceId', 'type', 'name'])
 
-def get_token(username, password):
+async def get_token(username, password):
     cookie = None
     config = {
         "username": username,
@@ -43,7 +43,7 @@ def get_token(username, password):
 
     try:
         session = requests.session()
-        response = session.get(url = BASE_URL + 'oidc/login')
+        response = await session.get(url = BASE_URL + 'oidc/login')
     except Exception as e:
         _LOGGER.e('Get Refresh Token Exception %s', str(e))
     else:
@@ -62,13 +62,13 @@ def get_token(username, password):
             'X-Requested-With': 'XMLHttpRequest',
         }
         try:
-            response = session.post(url = action, data = payload, cookies = cookie, allow_redirects=False)
+            response = await session.post(url = action, data = payload, cookies = cookie, allow_redirects=False)
         except Exception as e:
             _LOGGER.e('Get Refresh Token Action Exception %s', str(e))
         else:
             ondus_url = response.next.url.replace('ondus', 'https')
             try:
-                response = session.get(url = ondus_url, cookies = cookie)
+                response = await session.get(url = ondus_url, cookies = cookie)
             except Exception as e:
                 _LOGGER.e('Get Refresh Token Response Exception %s', str(e))
             else:
@@ -79,7 +79,7 @@ def get_token(username, password):
 async def async_setup(hass, config):
     _LOGGER.debug("Loading Grohe Sense")
 
-    await initialize_shared_objects(hass, get_token(config.get(DOMAIN).get(CONF_USERNAME), config.get(DOMAIN).get(CONF_PASSWORD)))
+    await initialize_shared_objects(hass, await get_token(config.get(DOMAIN).get(CONF_USERNAME), config.get(DOMAIN).get(CONF_PASSWORD)))
 
     await hass.helpers.discovery.async_load_platform('sensor', DOMAIN, {}, config)
     await hass.helpers.discovery.async_load_platform('switch', DOMAIN, {}, config)

--- a/__init__.py
+++ b/__init__.py
@@ -169,7 +169,7 @@ class OauthSession:
                         else:
                             _LOGGER.error('Grohe sense refresh token is invalid (or expired), please update your configuration with a new refresh token')
                             self._refresh_token = get_token(self._session, self._username, self._password)
-                            token = await auth_token.token(token)
+                            token = await self.token(token)
                     else:
                         _LOGGER.debug('Request to %s returned status %d, %s', url, response.status, await response.text())
             except OauthException as oe:

--- a/__init__.py
+++ b/__init__.py
@@ -80,7 +80,7 @@ async def async_setup(hass, config):
 
 async def initialize_shared_objects(hass, username, password):
     session = aiohttp_client.async_get_clientsession(hass)
-    auth_session = OauthSession(session, username, password)
+    auth_session = OauthSession(session, username, password, await get_token(session, username, password))
     devices = []
 
     hass.data[DOMAIN] = { 'session': auth_session, 'devices': devices }
@@ -105,11 +105,11 @@ class OauthException(Exception):
         self.reason = reason
 
 class OauthSession:
-    def __init__(self, session, username, password):
+    def __init__(self, session, username, password, refresh_token):
         self._session = session
         self._username = username
         self._password = password
-        self._refresh_token = get_token(self._session, self._username, self._password)
+        self._refresh_token = refresh_token
         self._access_token = None
         self._fetching_new_token = None
 

--- a/__init__.py
+++ b/__init__.py
@@ -34,7 +34,7 @@ GROHE_SENSE_GUARD_TYPE = 103 # Type identifier for sense guard, the water guard 
 
 GroheDevice = collections.namedtuple('GroheDevice', ['locationId', 'roomId', 'applianceId', 'type', 'name'])
 
-async def get_token(username, password):
+async def get_token(hass, username, password):
     cookie = None
     config = {
         "username": username,
@@ -42,8 +42,8 @@ async def get_token(username, password):
     }
 
     try:
-        session = requests.session()
-        response = await session.get(url = BASE_URL + 'oidc/login')
+        session = aiohttp_client.async_get_clientsession(hass)
+        response = await session.get(BASE_URL + 'oidc/login')
     except Exception as e:
         _LOGGER.e('Get Refresh Token Exception %s', str(e))
     else:
@@ -79,7 +79,7 @@ async def get_token(username, password):
 async def async_setup(hass, config):
     _LOGGER.debug("Loading Grohe Sense")
 
-    await initialize_shared_objects(hass, await get_token(config.get(DOMAIN).get(CONF_USERNAME), config.get(DOMAIN).get(CONF_PASSWORD)))
+    await initialize_shared_objects(hass, await get_token(hass, config.get(DOMAIN).get(CONF_USERNAME), config.get(DOMAIN).get(CONF_PASSWORD)))
 
     await hass.helpers.discovery.async_load_platform('sensor', DOMAIN, {}, config)
     await hass.helpers.discovery.async_load_platform('switch', DOMAIN, {}, config)

--- a/__init__.py
+++ b/__init__.py
@@ -66,7 +66,7 @@ async def get_token(hass, username, password):
             except Exception as e:
                 _LOGGER.error('Get Refresh Token Response Exception %s', str(e))
             else:
-                response_json = json.loads(response.text())
+                response_json = json.loads(await response.text())
 
     return response_json['refresh_token']
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
 	"domain": "grohe_sense",
+	"version": "0.0.1",
 	"name": "Grohe Sense",
-	"documentation": "https://github.com/gkreitz/homeassistant-grohe_sense",
+	"documentation": "https://github.com/rusucosmin/homeassistant-grohe_sense",
 	"dependencies": [],
 	"requirements": [],
-	"codeowners": ["@gkreitz"]
+	"codeowners": ["@gkreitz", "@rusucosmin"]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
 	"domain": "grohe_sense",
 	"version": "0.0.1",
 	"name": "Grohe Sense",
-	"documentation": "https://github.com/rusucosmin/homeassistant-grohe_sense",
+	"documentation": "https://github.com/gkreitz/homeassistant-grohe_sense",
 	"dependencies": [],
 	"requirements": [],
-	"codeowners": ["@gkreitz", "@rusucosmin"]
+	"codeowners": ["@gkreitz"]
 }

--- a/sensor.py
+++ b/sensor.py
@@ -5,7 +5,7 @@ from datetime import (datetime, timezone, timedelta)
 
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
-from homeassistant.const import (STATE_UNAVAILABLE, STATE_UNKNOWN, TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE, PERCENTAGE, DEVICE_CLASS_HUMIDITY, VOLUME_FLOW_RATE_CUBIC_METERS_PER_HOUR, PRESSURE_MBAR, DEVICE_CLASS_PRESSURE, TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE, VOLUME_LITERS)
+from homeassistant.const import (STATE_UNAVAILABLE, STATE_UNKNOWN, TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE, PERCENTAGE, DEVICE_CLASS_HUMIDITY, VOLUME_FLOW_RATE_CUBIC_METERS_PER_HOUR, PRESSURE_BAR, DEVICE_CLASS_PRESSURE, TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE, VOLUME_LITERS)
 
 from homeassistant.helpers import aiohttp_client
 
@@ -21,7 +21,7 @@ SENSOR_TYPES = {
         'temperature': SensorType(TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE, lambda x : x),
         'humidity': SensorType(PERCENTAGE, DEVICE_CLASS_HUMIDITY, lambda x : x),
         'flowrate': SensorType(VOLUME_FLOW_RATE_CUBIC_METERS_PER_HOUR, None, lambda x : x * 3.6),
-        'pressure': SensorType(PRESSURE_MBAR, DEVICE_CLASS_PRESSURE, lambda x : x * 1000),
+        'pressure': SensorType(PRESSURE_BAR, DEVICE_CLASS_PRESSURE, lambda x : x * 1000),
         'temperature_guard': SensorType(TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE, lambda x : x),
         }
 


### PR DESCRIPTION
Currently, after the refresh_token expires, the app automatically generates a new one. However, when you restart Home Assistant, it actually picks up the old one (the one that's stored in your config file). As such, the integration typically fails after some time, at the next Home Assistant restart.

I've changed the config to be able to specify your username and password, and it will get the first refresh_token automatically. Tested with my local HA and everything seems to be working smoothly. 